### PR TITLE
Add sequential second self-attention and feed-forward layers

### DIFF
--- a/MathNetClasses/TrainingFramework.cs
+++ b/MathNetClasses/TrainingFramework.cs
@@ -65,6 +65,8 @@ public static class TrainingFramework
         model.Create03_CreatePositionalEncoding(inputSize);
         model.Create04_CreateSelfAttention();
         model.Create05_CreateFeedForward();
+        model.Create04b_CreateSelfAttention2();
+        model.Create05b_CreateFeedForward2();
         model.Create06_CreateOutputProjection();
         model.Create07_SetupNoise(noiseVal, percentToChange);
         model.SaveModel();


### PR DESCRIPTION
## Summary
- extend model to include an extra self-attention and feed-forward pair
- persist/load additional layers
- update training framework to build models with the new layers

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6866b6403ff0832cb282806ef67ab8e7